### PR TITLE
Fix args in deploy manifest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -28,7 +28,7 @@ spec:
                 # name:  ensembl-species-search-duckdb-configmap
           command: ["uvicorn"]
           args: [
-            "main.app",
+            "main:app",
             "--host",
             "0.0.0.0",
             "--port",


### PR DESCRIPTION
Tiny change to fix typo in the deployment. APP argument to the uvicorn should be in format `<module>:<attribute> `
